### PR TITLE
Fix Esa::Response#headers and implement its spec

### DIFF
--- a/lib/esa/response.rb
+++ b/lib/esa/response.rb
@@ -11,7 +11,7 @@ module Esa
     end
 
     def headers
-      @headers ||= @raw_headers.headers.inject({}) do |result, (key, value)|
+      @headers ||= @raw_headers.inject({}) do |result, (key, value)|
         result.merge(key.split("-").map(&:capitalize).join("-") => value)
       end
     end

--- a/spec/esa/response_spec.rb
+++ b/spec/esa/response_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+RSpec.describe Esa::Response do
+  let(:response_status) { 401 }
+  let(:response_body) { '{"error":"unauthorized", "message":"Unauthorized"}' }
+  let(:response_headers) do
+    {
+      'server' => 'Cowboy',
+      'content-type' => 'application/json; charset=utf-8',
+    }
+  end
+  let(:connection) do
+    Faraday.new do |c|
+      c.adapter :test, Faraday::Adapter::Test::Stubs.new do |stub|
+        stub.get('/test') { [response_status, response_headers, response_body] }
+      end
+    end
+  end
+  let(:response) { described_class.new(connection.get('/test')) }
+
+  describe '#body' do
+    subject { response.body }
+    it { is_expected.to eq response_body }
+  end
+
+  describe '#headers' do
+    subject { response.headers }
+    let(:expectation) do
+      {
+        'Server' => 'Cowboy',
+        'Content-Type' => 'application/json; charset=utf-8',
+      }
+    end
+
+    it { is_expected.to eq expectation }
+  end
+
+  describe '#status' do
+    subject { response.status }
+    it { is_expected.to eq response_status }
+  end
+end


### PR DESCRIPTION
Previously, `Esa::Response#headers` raised an error like ``"undefined method `headers' for #<Faraday::Utils::Headers:0x007f104302d2f8>"``.

This PR fixes that and implements its spec.