### PR TITLE
Esa::Client#upload_attachment needs 'multi_xml' gem

### DIFF
--- a/esa.gemspec
+++ b/esa.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "faraday", "~> 0.9"
   spec.add_runtime_dependency "faraday_middleware"
   spec.add_runtime_dependency "mime-types", '~> 2.6'
+  spec.add_runtime_dependency "multi_xml", '~> 0.5.5'
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "pry"


### PR DESCRIPTION
```
client = Esa::Client.new(
  access_token: access_token,
  current_team: team_name, # 移行先のチーム名(サブドメイン)
)

client.upload_attachment(['http://example.com/hoge.jpg', 'hoge=fugo'])
```

```
RuntimeError: missing dependency for FaradayMiddleware::ParseXml: cannot load such file -- multi_xml
```