### PR TITLE
Enable to set headers for remote url on #upload_attachment

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,10 +130,11 @@ client.tags
 #=> GET /v1/teams/foobar/tags
 
 # Upload Attachment(beta)
-client.upload_attachment('/Users/foo/Desktop/foo.png')               # Path
-client.upload_attachment(File.open('/Users/foo/Desktop/foo.png'))    # File
-client.upload_attachment('http://example.com/foo.png')               # Remote URL
-client.upload_attachment(['http://example.com/foo.png', cookie_str]) # Remote URL + Cookie
+client.upload_attachment('/Users/foo/Desktop/foo.png')                 # Path
+client.upload_attachment(File.open('/Users/foo/Desktop/foo.png'))      # File
+client.upload_attachment('http://example.com/foo.png')                 # Remote URL
+client.upload_attachment(['http://example.com/foo.png', cookie_str])   # Remote URL + Cookie
+client.upload_attachment(['http://example.com/foo.png', headers_hash]) # Remote URL + Headers
 
 # Signed url for secure upload(beta)
 client.signed_url('uploads/p/attachments/1/2016/08/16/1/foobar.png')

--- a/lib/esa/api_methods.rb
+++ b/lib/esa/api_methods.rb
@@ -169,14 +169,18 @@ module Esa
     end
 
     def file_from(path_or_file_or_url)
-      path_or_file_or_url, cookie = *path_or_file_or_url if path_or_file_or_url.is_a?(Array)
+      path_or_file_or_url, headers_or_cookie = *path_or_file_or_url if path_or_file_or_url.is_a?(Array)
 
       if path_or_file_or_url.respond_to?(:read)
         path_or_file_or_url
       elsif path_or_file_or_url.is_a?(String) && HTTP_REGEX.match(path_or_file_or_url)
         remote_url = path_or_file_or_url
-        headers = {}
-        headers[:Cookie] = cookie if cookie
+        headers =
+          if headers_or_cookie
+            headers_or_cookie.is_a?(Hash) ? headers_or_cookie : { Cookie: headers_or_cookie }
+          else
+            {}
+          end
         response = send_simple_request(:get, remote_url, nil, headers)
         raise RemoteURLNotAvailableError, "#{remote_url} is not available." unless response.status == 200
         PathStringIO.new(File.basename(remote_url), response.body)


### PR DESCRIPTION
(\\( •̀ө•́)/)

```rb
client = Esa::Client.new(access_token: "xxx", current_team: "xxx")
token = "xxx"
url = "https://xxx.qiita.com/files/xxx.png"
client.upload_attachment([url, { Authorization: "Bearer #{token}" }])
```