### PR TITLE
Use rspec-nc without CI

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,4 @@
 --color
 --require spec_helper
---format=progress --format=Nc
+--format=progress
+<%= "--format=Nc" unless ENV["CI"] %>


### PR DESCRIPTION
Hi,
I see [the recent job on CI](https://travis-ci.org/esaio/esa-ruby/jobs/296131396) is failed.
CI's backtraces show `rspec-nc` failed because it supports on macOS 10.10 or higher, not linux. So this PR doesn't specify `"--format-nc"` in CI.

Sorry to make the PR without any issue. Thanks!