### PR TITLE
Remove EOL Ruby version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,6 @@ jobs:
     strategy:
       matrix:
         ruby:
-        - '2.5'
-        - '2.6'
         - '2.7'
         - '3.0'
         - '3.1'


### PR DESCRIPTION
ref: https://www.ruby-lang.org/en/downloads/branches/

```
Ruby 2.6
status: eol
release date: 2018-12-25
EOL date: 2022-04-12

Ruby 2.5
status: eol
release date: 2017-12-25
EOL date: 2021-04-05
```