### PR TITLE
Update actions/checkout@v2 -> v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         - 'head'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
Annotation が出ていたので〜

https://github.com/yamashush/esa-ruby/actions/runs/3666829504

```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2
```

動作確認
https://github.com/yamashush/esa-ruby/actions/runs/3666922714/

![image](https://user-images.githubusercontent.com/38120991/206883540-089cd2e7-47cb-46cd-8798-634ded4dc8af.png)

