### PR TITLE
Request to add `base64` gem dependency to `esa` gem

### DIFF
--- a/esa.gemspec
+++ b/esa.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.7.0"
 
+  spec.add_runtime_dependency 'base64', '>= 0.2'
   spec.add_runtime_dependency 'faraday', '>= 2.0.1', '< 3.0'
   spec.add_runtime_dependency 'faraday-multipart'
   spec.add_runtime_dependency 'faraday-xml'


### PR DESCRIPTION
I am writing to inform you about a deprecation warning related to the `base64` library that will affect the `esa` gem. The warning states that `base64` was loaded from the standard library but will no longer be part of the default gems since Ruby 3.4.0.

To resolve this issue and ensure compatibility with future Ruby versions, could you please add `base64` to the gemspec of the `esa` gem?

Here is the warning message:

```
warning: base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec. Also contact author of esa-2.1.0 to add base64 into its gemspec.
```

I believe that this pull request will solve the problem.