### PR TITLE
Drop Support for Ruby < 3.1

### DIFF
--- a/esa.gemspec
+++ b/esa.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.1.0"
 
   spec.add_runtime_dependency 'base64', '>= 0.2'
   spec.add_runtime_dependency 'faraday', '>= 2.0.1', '< 3.0'


### PR DESCRIPTION
- fix #66 

Drop support for Ruby < 3.1