### PR TITLE
Revert "Add dependabot for bundler"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,3 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-- package-ecosystem: "bundler"
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  versioning-strategy: lockfile-only


### PR DESCRIPTION
Reverts esaio/esa-ruby#68

Gemfile.lock がgit管理下にないので不要か