### PR TITLE
Support revision API

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ client.revisions(post_number)
 client.revision(post_number, revision_number)
 #=> GET /v1/teams/foobar/posts/1/revisions
 
-client.compare_revisions(post_number, from...to)
+client.compare_revisions(post_number, from, to)
 #=> GET /v1/teams/foobar/posts/1/revisions/compare/1...2
 
 

--- a/lib/esa/api_methods.rb
+++ b/lib/esa/api_methods.rb
@@ -61,8 +61,8 @@ module Esa
       send_get("/v1/teams/#{current_team!}/posts/#{post_number}/revisions/#{revision_number}", params, headers)
     end
 
-    def compare_revisions(post_number, revision_range, params = nil, headers = nil)
-      send_get("/v1/teams/#{current_team!}/posts/#{post_number}/revisions/compare/#{revision_range}", params, headers)
+    def compare_revisions(post_number, from_revision_number, to_revision_number, params = nil, headers = nil)
+      send_get("/v1/teams/#{current_team!}/posts/#{post_number}/revisions/compare/#{from_revision_number}...#{to_revision_number}", params, headers)
     end
 
     def delete_post(post_number, params = nil, headers = nil)


### PR DESCRIPTION
## Revision API

以下に対応しました。

- `GET /v1/%{team_name}/post/%{post_number}/revisions`
- `GET /v1/%{team_name}/post/%{post_number}/revisions/%{revision_number}`
- `GET /v1/%{team_name}/post/%{post_number}/revisions/compare/%{from_revision_number}...%{to_revision_number}`