### PR TITLE
Bump bundler to 4.0.12 and allow ruby-head to fail

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.ruby == 'head' }}
     strategy:
+      fail-fast: false
       matrix:
         ruby:
           - "3.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,4 +84,4 @@ DEPENDENCIES
   webmock (~> 3.26.1)
 
 BUNDLED WITH
-  4.0.6
+  4.0.12


### PR DESCRIPTION
## Why

PR #95 などで `build (head)` ジョブが失敗し、それに巻き込まれて他の Ruby バージョンのジョブも `CANCELLED` になっていた。

原因は **Bundler 4.0.6** が Ruby 4.1.0dev (ruby-head) で削除された内部定数 `Pathname::SEPARATOR_PAT` を参照しており、テスト実行前の `bundle install` 段階で `NameError` を起こしていたこと。Bundler 4.0.9 の修正 (`Use Pathname#absolute?`, rubygems#9529) で解消済み。

## What

- `Gemfile.lock`: `BUNDLED WITH` 4.0.6 → 4.0.12
- `.github/workflows/build.yml`:
  - `continue-on-error: ${{ matrix.ruby == 'head' }}` — 開発版 Ruby の失敗でワークフロー全体を落とさない
  - `fail-fast: false` — head の失敗で他マトリクスを巻き添えキャンセルしない

ローカル (Ruby 4.0.5 / Bundler 4.0.12) で `bundle exec rspec` 通過確認済み (15 examples, 0 failures)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)