### PR TITLE
Add prepend_post API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ client.update_post(post_number, name: 'bar')
 client.append_post(post_number, content: 'bar')
 #=> POST /v1/teams/foobar/posts/1/append
 
+# (beta)
+client.prepend_post(post_number, content: 'bar')
+#=> POST /v1/teams/foobar/posts/1/prepend
+
 client.delete_post(post_number)
 #=> DELETE /v1/teams/foobar/posts/1
 

--- a/lib/esa/api_methods.rb
+++ b/lib/esa/api_methods.rb
@@ -53,6 +53,10 @@ module Esa
       send_post("/v1/teams/#{current_team!}/posts/#{post_number}/append", wrap(params, :post), headers)
     end
 
+    def prepend_post(post_number, params = nil, headers = nil)
+      send_post("/v1/teams/#{current_team!}/posts/#{post_number}/prepend", wrap(params, :post), headers)
+    end
+
     def revisions(post_number, params = nil, headers = nil)
       send_get("/v1/teams/#{current_team!}/posts/#{post_number}/revisions", params, headers)
     end


### PR DESCRIPTION
## 概要

append API と同様に prepend API に対応しました。

## 変更内容

- `lib/esa/api_methods.rb`: `append_post` に倣って `prepend_post` メソッドを追加（`/v1/teams/:team/posts/:post_number/prepend` に POST）
- `README.md`: 使用例を追加（append と同じく `# (beta)` 表記）

## 補足

`append_post` にテストが存在しないため、それに倣って今回もテストは追加していません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)