### PR TITLE
Add create_attachment instead of upload_attachment

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,17 @@ client.create_emoji(code: 'alias_code', origin_code: 'team_emoji')
 client.delete_emoji('team_emoji')
 #=> DELETE /v1/teams/foobar/emojis/team_emoji
 
-# Upload Attachment(beta)
+# Upload Attachment
+client.create_attachment('/Users/foo/Desktop/foo.png')                 # Path
+client.create_attachment(File.open('/Users/foo/Desktop/foo.png'))      # File
+client.create_attachment('http://example.com/foo.png')                 # Remote URL
+client.create_attachment(['http://example.com/foo.png', cookie_str])   # Remote URL + Cookie
+client.create_attachment(['http://example.com/foo.png', headers_hash]) # Remote URL + Headers
+client.create_attachment('/Users/foo/Desktop/foo.png', name: 'bar.png') # Path + Name
+#=> POST /v1/teams/foobar/attachments
+#=> { "attachment" => { "url" => "https://img.esa.io/uploads/...", "name" => "foo.png", "size" => 12345, "content_type" => "image/png" } }
+
+# Upload Attachment(beta): deprecated, use create_attachment instead
 client.upload_attachment('/Users/foo/Desktop/foo.png')                 # Path
 client.upload_attachment(File.open('/Users/foo/Desktop/foo.png'))      # File
 client.upload_attachment('http://example.com/foo.png')                 # Remote URL

--- a/lib/esa/api_methods.rb
+++ b/lib/esa/api_methods.rb
@@ -196,8 +196,23 @@ module Esa
       end
     end
 
-    # beta
+    def create_attachment(path_or_file_or_url, params = {}, headers = nil)
+      file = file_from(path_or_file_or_url)
+      content_type = params.delete(:content_type) || content_type_from_file(file) || 'application/octet-stream'
+
+      form_data = { file: Faraday::FilePart.new(file, content_type) }
+      form_data[:name] = params[:name] if params[:name]
+
+      send_multipart_post("/v1/teams/#{current_team!}/attachments", form_data, headers)
+    end
+
+    # deprecated: Use #create_attachment instead
     def upload_attachment(path_or_file_or_url, params = {}, headers = nil)
+      unless @upload_attachment_deprecation_warned
+        warn '[DEPRECATION] `upload_attachment` is deprecated. Use `create_attachment` instead.'
+        @upload_attachment_deprecation_warned = true
+      end
+
       file = file_from(path_or_file_or_url)
       setup_params_for_upload(params, file)
 

--- a/lib/esa/client.rb
+++ b/lib/esa/client.rb
@@ -43,8 +43,12 @@ module Esa
       send_request(:delete, path, params, headers)
     end
 
-    def send_request(method, path, params = nil, headers = nil)
-      response = esa_connection.send(method, path, params, headers)
+    def send_multipart_post(path, params = nil, headers = nil)
+      send_request(:post, path, params, headers, connection: multipart_connection)
+    end
+
+    def send_request(method, path, params = nil, headers = nil, connection: esa_connection)
+      response = connection.send(method, path, params, headers)
       raise TooManyRequestError if retry_on_rate_limit_exceeded && response.status == 429 # too_many_requests
       Esa::Response.new(response)
     rescue TooManyRequestError
@@ -66,6 +70,16 @@ module Esa
       @esa_connection ||= Faraday.new(faraday_options) do |c|
         faraday_middlewares.each { |faraday_middleware| c.use faraday_middleware }
         c.request :json
+        c.response :json
+        c.adapter Faraday.default_adapter
+      end
+    end
+
+    def multipart_connection
+      @multipart_connection ||= Faraday.new(faraday_options) do |c|
+        faraday_middlewares.each { |faraday_middleware| c.use faraday_middleware }
+        c.request :multipart
+        c.request :url_encoded
         c.response :json
         c.adapter Faraday.default_adapter
       end

--- a/spec/esa/client_spec.rb
+++ b/spec/esa/client_spec.rb
@@ -102,6 +102,55 @@ RSpec.describe Esa::Client do
     end
   end
 
+  describe '#create_attachment' do
+    let(:current_team) { 'test-team' }
+    let(:file) { File.open('spec/fixtures/files/egg.png') }
+
+    before do
+      stub_request(:post, "https://api.esa.io/v1/teams/test-team/attachments")
+        .to_return(
+          status: 201,
+          body: {
+            attachment: {
+              url: 'https://img.esa.io/uploads/test.png',
+              name: 'egg.png',
+              size: 49816,
+              content_type: 'image/png'
+            }
+          }.to_json,
+          headers: {
+            'Content-Type' => 'application/json; charset=utf-8'
+          }
+        )
+    end
+
+    it 'uploads file as multipart/form-data and returns attachment' do
+      response = client.create_attachment(file)
+
+      expect(response.status).to eq(201)
+      expect(response.body['attachment']['url']).to eq('https://img.esa.io/uploads/test.png')
+      expect(
+        a_request(:post, "https://api.esa.io/v1/teams/test-team/attachments").with do |req|
+          req.headers['Content-Type'].start_with?('multipart/form-data') &&
+            req.body.include?('name="file"; filename="egg.png"') &&
+            req.body.include?('Content-Type: image/png')
+        end
+      ).to have_been_made
+    end
+
+    context 'with name param' do
+      it 'sends name as a form field' do
+        client.create_attachment(file, name: 'renamed.png')
+
+        expect(
+          a_request(:post, "https://api.esa.io/v1/teams/test-team/attachments").with do |req|
+            req.body.include?('name="name"') && req.body.include?('renamed.png')
+          end
+        ).to have_been_made
+      end
+    end
+  end
+
   describe '#upload_attachment' do
     let(:current_team) { 'test-team' }
     let(:file) { File.open('spec/fixtures/files/egg.png') }
@@ -139,6 +188,11 @@ RSpec.describe Esa::Client do
     it 'return URL for uploaded attachment'do
       response = client.upload_attachment(file)
       expect(response.body['attachment']['url']).to eq('https://example.com/test.png')
+    end
+
+    it 'warns deprecation once' do
+      expect { client.upload_attachment(file) }.to output(/deprecated/).to_stderr
+      expect { client.upload_attachment(File.open('spec/fixtures/files/egg.png')) }.not_to output.to_stderr
     end
   end
 end


### PR DESCRIPTION
## 概要

新しいファイルアップロードAPI `POST /v1/teams/:team/attachments` を使う `create_attachment` メソッドを追加します。

```ruby
client.create_attachment('/path/to/foo.png')
client.create_attachment(File.open('/path/to/foo.png'))
client.create_attachment('http://example.com/foo.png')                  # Remote URL
client.create_attachment(['http://example.com/foo.png', cookie_str])    # Remote URL + Cookie
client.create_attachment('/path/to/foo.png', name: 'bar.png')           # 名前を指定
#=> POST /v1/teams/foobar/attachments (multipart/form-data)
#=> { "attachment" => { "url" => ..., "name" => ..., "size" => ..., "content_type" => ... } }
```

## 方針

- メソッド名は `create_post` / `create_comment` 等の既存の命名、およびエンドポイント（`attachments#create`）と揃えて `create_attachment`
- 入力形式（パス / File / リモートURL / [URL, Cookie or ヘッダ]）は `upload_attachment` と同じものをサポート（`file_from` を再利用）。加えて `name:` パラメータでファイル名指定可
- content_type は 指定 → mime-types 推測 → `application/octet-stream` の順でフォールバック（サーバー側で magic bytes 判定されるため best effort でよい）
- multipart 送信用に APIヘッダ付きの `multipart_connection` を追加し、`send_request` に `connection:` キーワードを足して 429 リトライを共有。新APIのアップロード専用スロットル（3 req / 10sec）にも既存のレートリミットリトライが効く

## 互換性

- `upload_attachment`（policies + S3 直POST フロー）は実装・挙動とも従来のまま動作します
- ただし初回呼び出し時に一度だけ deprecation warning を stderr に出すようにしました（インスタンスごとに1回）
- README では新APIを主に記載し、旧記述は deprecated 表記でそのまま残しています

## テスト

- `#create_attachment`: multipart ボディ（filename / Content-Type）の検証、201 レスポンスのパース、`name:` 指定時のフォームフィールド送信
- `#upload_attachment`: 既存spec無変更 + deprecation warning が一度だけ出ることを追加
- `bundle exec rspec`: 18 examples, 0 failures

## その他

- バージョン bump（3.6.0 → 3.7.0）はリリース時に別途行う想定で本PRには含めていません

🤖 Generated with [Claude Code](https://claude.com/claude-code)