### PR TITLE
CI: Use latest bundler for ruby-head

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,9 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          # ruby-head: Gemfile.lock の BUNDLED WITH と head 同梱の dev 版 Bundler の
+          # 不一致で Bundler::CorruptBundlerInstallError になるため latest を使う
+          bundler: ${{ matrix.ruby == 'head' && 'latest' || 'default' }}
           bundler-cache: true
       - name: Install dependencies
         run: bundle install --jobs 4 --retry 3


### PR DESCRIPTION
## 概要

CI の `build (head)` ジョブが `Bundler::CorruptBundlerInstallError` で失敗し続けているため、ruby-head のときだけ setup-ruby に `bundler: latest` を指定します。

## 背景

- Gemfile.lock の `BUNDLED WITH`（4.0.12）に従って setup-ruby が Bundler 4.0.12 をインストールするが、ruby-head スナップショット同梱の default Bundler（4.1.0.dev）の spec と不一致になり、`bundle exec rake` から起動した rspec の内側プロセスで `Bundler::CorruptBundlerInstallError` が発生する
- master でも同様に失敗しており（例: [6/30 の build run](https://github.com/esaio/esa-ruby/actions/runs/28412079291)）、PR #102 とは無関係の既存問題
- `continue-on-error` により run 全体は green になるが、ジョブ単位の ✗ が紛らわしいので解消したい

## 変更

- ruby-head のときだけ `bundler: latest` を指定（他のバージョンは従来どおり `default` = Gemfile.lock の BUNDLED WITH に従う）

## 確認方法

この PR の CI で `build (head)` が通ることを確認する。それでも同じエラーが出る場合は `bundler: none`（head 同梱の dev 版 Bundler をそのまま使う）への切り替えを検討。

🤖 Generated with [Claude Code](https://claude.com/claude-code)