### PR TITLE
Add child team API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,25 @@ delete_by_email_address = 'alice@example.com'
 client.delete_member(delete_by_email_address)
 #=> DELETE /v1/teams/bar/members/alice@example.com
 
+# Child Team API (requires owner permission on the parent team)
+client.child_teams
+#=> GET /v1/teams/bar/child_teams
+
+# requires v2 token read:child_team_member
+client.child_team_members('sub')
+#=> GET /v1/teams/bar/child_teams/sub/members
+
+# requires v2 token read:child_team_member
+client.child_team_member('sub', 'alice')
+#=> GET /v1/teams/bar/child_teams/sub/members/alice
+
+client.child_team_member('sub', 'alice@example.com')
+#=> GET /v1/teams/bar/child_teams/sub/members/alice@example.com
+
+# requires v2 token delete:child_team_member
+client.delete_child_team_member('sub', 'alice')
+#=> DELETE /v1/teams/bar/child_teams/sub/members/alice
+
 # Post API
 client.posts
 #=> GET /v1/teams/foo/posts

--- a/lib/esa/api_methods.rb
+++ b/lib/esa/api_methods.rb
@@ -33,6 +33,22 @@ module Esa
       send_delete("/v1/teams/#{current_team!}/members/#{screen_name}", params, headers)
     end
 
+    def child_teams(params = nil, headers = nil)
+      send_get("/v1/teams/#{current_team!}/child_teams", params, headers)
+    end
+
+    def child_team_members(child_team_name, params = nil, headers = nil)
+      send_get("/v1/teams/#{current_team!}/child_teams/#{child_team_name}/members", params, headers)
+    end
+
+    def child_team_member(child_team_name, identifier, params = nil, headers = nil)
+      send_get("/v1/teams/#{current_team!}/child_teams/#{child_team_name}/members/#{identifier}", params, headers)
+    end
+
+    def delete_child_team_member(child_team_name, screen_name, params = nil, headers = nil)
+      send_delete("/v1/teams/#{current_team!}/child_teams/#{child_team_name}/members/#{screen_name}", params, headers)
+    end
+
     def posts(params = nil, headers = nil)
       send_get("/v1/teams/#{current_team!}/posts", params, headers)
     end


### PR DESCRIPTION
## 概要

連結請求で紐付いた子チームを扱う API に対応しました。親チームの owner が、子チームの一覧と
そのメンバーを取得できます。

```ruby
client = Esa::Client.new(access_token: "<access_token>", current_team: 'bar')

client.child_teams
#=> GET /v1/teams/bar/child_teams

client.child_team_members('sub')
#=> GET /v1/teams/bar/child_teams/sub/members

client.child_team_member('sub', 'alice')
client.child_team_member('sub', 'alice@example.com')
#=> GET /v1/teams/bar/child_teams/sub/members/alice

client.delete_child_team_member('sub', 'alice')
#=> DELETE /v1/teams/bar/child_teams/sub/members/alice
```

子チームのメンバーを扱う3メソッドは v2 token の `read:child_team_member` /
`delete:child_team_member` が必要です。

## 変更内容

- `lib/esa/api_methods.rb`: 上記4メソッドを追加
- `README.md`: Child Team API の使用例を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lb7Mgptgn9MXvs4CcZL7AA
